### PR TITLE
Make `fetch_layer_metadata()` more flexible

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,0 @@
-Version: 0.1.0
-Date: 2024-01-10 16:18:32 UTC
-SHA: 5a834aac2c9392bfdc2888a76a85ffacd21205c1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # arcgisutils (development version)
 
-* Define `arc_token()` to get "ARCGIS_TOKEN" environment variable. This ensures that empty strings do not cause HTTP 498 "invalid token" error by returning `NULL` in stead of an empty string. ([#6](https://github.com/R-ArcGIS/arcgisutils/pull/6))
+* `fetch_layer_metadata()` now puts `f=json` in the url instead of the request body
+  - accepts `NULL` tokens 
+  - uses `req_auth_bearer_token()` to include token in header
+  - <https://github.com/R-ArcGIS/arcgisutils/pull/8>
+* Define `arc_token()` to get "ARCGIS_TOKEN" environment variable. This ensures that empty strings do not cause HTTP 498 "invalid token" error by returning `NULL` in stead of an empty string. ([#6](https://github.com/R-ArcGIS/arcgisutils/pull/6)) [@kbvernon](https://github.com/kbvernon)
 
 # arcgisutils 0.1.1
 

--- a/R/utils-requests.R
+++ b/R/utils-requests.R
@@ -31,20 +31,27 @@
 #' - `fetch_layer_metadata()` returns a list object
 #' - `count_features()` returns a scalar integer
 fetch_layer_metadata <- function(request, token) {
-  req_url <- httr2::req_body_form(
-    request,
-    f = "json",
-    token = token
-  )
 
+  # add f=json to the url for querying
+  req <- httr2::req_url_query(request, f = "json")
+
+  # add the token
+  if (!is.null(token)) {
+    req <- httr2::req_auth_bearer_token(req, token)
+  }
+
+  # process the request and capture the response string
   resp_string <- httr2::resp_body_string(
-    httr2::req_perform(req_url)
+    httr2::req_perform(req)
   )
 
+  # process the response string
   meta <- RcppSimdJson::fparse(resp_string)
 
+  # check if any errors occurred
   detect_errors(meta)
 
+  # return the list
   meta
 }
 

--- a/R/utils-requests.R
+++ b/R/utils-requests.R
@@ -36,7 +36,7 @@ fetch_layer_metadata <- function(request, token) {
   req <- httr2::req_url_query(request, f = "json")
 
   # add the token
-  if (!is.null(token)) {
+  if (!is.null(token) && nzchar(token)) {
     req <- httr2::req_auth_bearer_token(req, token)
   }
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -34,5 +34,7 @@ reference:
 - title: Utilities
   contents:
   - arc_host
+  - arc_token
   - compact
+
 

--- a/tests/testthat/test-fetch_layer_metadata.R
+++ b/tests/testthat/test-fetch_layer_metadata.R
@@ -1,0 +1,20 @@
+test_that("fetch_layer_metadata() NULL and empty string", {
+  furl <- "http://services.arcgisonline.com/arcgis/rest/services/USA_Topo_Maps/MapServer"
+  req <- httr2::request(furl)
+
+  expect_equal(
+    fetch_layer_metadata(req, NULL),
+    fetch_layer_metadata(req, "")
+  )
+})
+
+test_that("fetch_layer_metadata() known working MapServer", {
+  furl <- "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer"
+  req <- httr2::request(furl)
+
+  # this works with no token provided as a null or nzchar
+  expect_equal(
+    fetch_layer_metadata(req, NULL),
+    fetch_layer_metadata(req, "")
+  )
+})

--- a/tests/testthat/test-fetch_layer_metadata.R
+++ b/tests/testthat/test-fetch_layer_metadata.R
@@ -1,5 +1,5 @@
 test_that("fetch_layer_metadata() NULL and empty string", {
-  furl <- "http://services.arcgisonline.com/arcgis/rest/services/USA_Topo_Maps/MapServer"
+  furl <- "https://services.arcgisonline.com/arcgis/rest/services/USA_Topo_Maps/MapServer"
   req <- httr2::request(furl)
 
   expect_equal(

--- a/tests/testthat/test-fetch_layer_metadata.R
+++ b/tests/testthat/test-fetch_layer_metadata.R
@@ -18,3 +18,14 @@ test_that("fetch_layer_metadata() known working MapServer", {
     fetch_layer_metadata(req, "")
   )
 })
+
+
+test_that("fetch_layer_metadata() works for private content", {
+  skip("must be done interactively")
+  furl <- "https://services1.arcgis.com/hLJbHVT9ZrDIzK0I/arcgis/rest/services/North%20Carolina%20SIDS%20sample/FeatureServer"
+  req <- httr2::request(furl)
+  token <- auth_code()
+
+  expect_no_error(fetch_layer_metadata(req, token$access_token))
+
+})


### PR DESCRIPTION
Closes #7 
@kbvernon reported that `https://services.arcgisonline.com/arcgis/rest/services/USA_Topo_Maps/MapServer` would not work with `arc_open()`. This was an idiosyncrasy where  `f=json` was being passed in the request body. But this service does not work with f=json in the body but requires it as a part of the url query. 

This PR makes sure that `f=json` is added to the URL instead of the body. The token, if present, is added using `httr2::req_auth_bearer_token()`.


