### PR TITLE
handle case where error is present in json

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # arcgisutils (development version)
 
-- `parse_esri_json()` will return an empty `data.frame` in the presence of empty results
+- `parse_esri_json()` will return an empty `data.frame` in the presence of empty results an error. If an error is present, the error is reported
 - Breaking change to how authorization tokens are handled
   - Tokens are now stored in internal environment `token_env`
   - `set_auth_token()` removed in favor of `set_arc_token()` 

--- a/R/util-parse-esri-json.R
+++ b/R/util-parse-esri-json.R
@@ -59,6 +59,11 @@ parse_esri_json <- function(string, ...) {
   # extract the geometry features
   fts_raw <- b_parsed[["features"]]
 
+  if (is.null(fts_raw)) {
+    report_errors(b_parsed)
+    return(data.frame())
+  }
+
   # if this is a logical vector of length one we need to abort
   if (is.logical(fts_raw) && length(fts_raw) == 1L) return(data.frame())
 

--- a/R/utils-requests.R
+++ b/R/utils-requests.R
@@ -98,6 +98,30 @@ detect_errors <- function(response, error_call = rlang::caller_env()) {
   }
 }
 
+#' @keywords internal
+#' @noRd
+report_errors <- function(response, error_call = rlang::caller_env()) {
+  e <- response[["error"]]
+  if (!is.null(e)) {
+    err_msg <- strwrap(
+      paste0("  Error", e$messageCode, ": ", e$message),
+      prefix = "    ",
+      initial = ""
+    )
+
+    full_msg <- c(
+      "Status code: ",
+      response[["error"]][["code"]],
+      "\n",
+      paste0(err_msg, collapse = "\n")
+    )
+
+    rlang::warn(
+      paste0(full_msg, collapse = ""),
+      call = error_call
+    )
+  }
+}
 
 #' Set user-agent for arcgisutils
 #'


### PR DESCRIPTION
This PR adjusts the `parse_esri_json()` function. When the json it encounters is an error, the error itself is reported. Then an empty data.frame is returned. 

This PR duplicates the `detect_errors()` function and calls `rlang::warn()` instead of `rlang::abort()`. I don't like this implementation, but in lieu of a rust-based JSON parsing library with consistent error handling, this will suffice. 

Related: https://github.com/R-ArcGIS/arcgislayers/issues/138