### PR TITLE
Add suppport for ESRI WKIDs within from_spatial_reference()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,9 @@ Authors@R: c(
     person("Martha", "Bass", role = "ctb",
            comment = c(ORCID = "0009-0004-0268-5426")),
     person("Eli", "Pousson", , "eli.pousson@gmail.com", role = "ctb",
-           comment = c(ORCID = "0000-0001-8280-1706"))
+           comment = c(ORCID = "0000-0001-8280-1706")),
+    person("Ryan", "Zomorrodi", , "ryanzomorrodi@gmail.com", role = "ctb",
+           comment = c(ORCID = "0009-0003-6417-5985"))
   )
 Description: Developer oriented utility functions designed to be used as
     the building blocks of R packages that work with ArcGIS Location

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # arcgisutils 0.5.0
 
+- `from_spatial_reference()` handles CRS WKIDs from the ESRI authority
 - Adds `from_envelope()` and `from_spatial_reference()` to handle processing lists that represent an Esri Envelope and Esri SpatialReference object converting them into sf `bbox` objects
 - Adds `auth_shiny()` and `oauth_provider_arcgis()` to support authentication in a Shiny application. [`{shinyOAuth}`](https://github.com/lukakoning/shinyOAuth/) is now a suggested package <https://github.com/R-ArcGIS/arcgisutils/pull/82>
 - Adds `gp_job_from_url()` which creates a new `arc_gp_job` from a given URL

--- a/R/geoprocessing-types.R
+++ b/R/geoprocessing-types.R
@@ -434,6 +434,7 @@ from_spatial_reference <- function(sr, error_call = rlang::caller_call()) {
 
   crs <- sr[["latestWkid"]] %||% sr[["wkid"]] %||% sr[["wkt"]]
 
+  # WKIDs 32767 and higher fall within the ESRI authority
   if (is.numeric(crs) && crs >= 32767) {
     crs <- paste0("ESRI:", crs)
   }

--- a/R/geoprocessing-types.R
+++ b/R/geoprocessing-types.R
@@ -433,6 +433,11 @@ from_spatial_reference <- function(sr, error_call = rlang::caller_call()) {
   }
 
   crs <- sr[["latestWkid"]] %||% sr[["wkid"]] %||% sr[["wkt"]]
+
+  if (is.numeric(crs) && crs >= 32767) {
+    crs <- paste0("ESRI:", crs)
+  }
+
   sf::st_crs(crs)
 }
 

--- a/tests/testthat/test-geoprocessing-types.R
+++ b/tests/testthat/test-geoprocessing-types.R
@@ -1,0 +1,17 @@
+test_that("from_spatial_reference works for EPSG WKIDs", {
+  sr <- list(wkid = 4326L)
+
+  expect_identical(
+    from_spatial_reference(sr),
+    sf::st_crs(sr$wkid)
+  )
+})
+
+test_that("from_spatial_reference works for ESRI WKIDs", {
+  sr <- list(wkid = 102003L)
+
+  expect_identical(
+    from_spatial_reference(sr),
+    sf::st_crs(paste0("ESRI:", sr$wkid))
+  )
+})


### PR DESCRIPTION
This PR is 1 of 3 aimed at solving https://github.com/R-ArcGIS/arcgislayers/issues/291.

You mentioned adding an warning to the user if a missing CRS is returned. Since arcpbf will use  `from_spatial_reference()` on the result of each request, I could see the user potentially getting a whole bunch of warnings. Is that still something you'd want to do?