### PR TITLE
Don't throw error when CRS is NA

### DIFF
--- a/R/geoprocessing-types.R
+++ b/R/geoprocessing-types.R
@@ -435,7 +435,7 @@ from_spatial_reference <- function(sr, error_call = rlang::caller_call()) {
   crs <- sr[["latestWkid"]] %||% sr[["wkid"]] %||% sr[["wkt"]]
 
   # WKIDs 32767 and higher fall within the ESRI authority
-  if (is.numeric(crs) && crs >= 32767) {
+  if (is.numeric(crs) && !is.na(crs) && crs >= 32767) {
     crs <- paste0("ESRI:", crs)
   }
 

--- a/tests/testthat/test-geoprocessing-types.R
+++ b/tests/testthat/test-geoprocessing-types.R
@@ -16,7 +16,7 @@ test_that("from_spatial_reference works for ESRI WKIDs", {
   )
 })
 
-test_that("from_spatial_reference works for ESRI WKIDs", {
+test_that("from_spatial_reference works for NA WKIDs", {
   sr <- list(wkid = NA_integer_)
 
   expect_identical(

--- a/tests/testthat/test-geoprocessing-types.R
+++ b/tests/testthat/test-geoprocessing-types.R
@@ -15,3 +15,12 @@ test_that("from_spatial_reference works for ESRI WKIDs", {
     sf::st_crs(paste0("ESRI:", sr$wkid))
   )
 })
+
+test_that("from_spatial_reference works for ESRI WKIDs", {
+  sr <- list(wkid = NA_integer_)
+
+  expect_identical(
+    from_spatial_reference(sr),
+    sf::NA_crs_
+  )
+})


### PR DESCRIPTION
The #90 pull request introduced an error when the CRS is a numeric NA (as pointed out by https://github.com/R-ArcGIS/arcpbf/pull/18#issuecomment-4417659542)